### PR TITLE
Standardise getenv call for EMAIL

### DIFF
--- a/classes/postal.php
+++ b/classes/postal.php
@@ -57,7 +57,7 @@ class Postal
                 if (\Fuel::$env != \Fuel::DEVELOPMENT) {
                     $message->to($ar_to_name.' <'.$ar_to_email.'>');
                 } else {
-                    $env = getenv('email');
+                    $env = getenv('EMAIL');
                     if (!$env) {
                         $env = 'root@localhost';
                     }


### PR DESCRIPTION
If sending an array of $to, the getenv check would potentially fail, in Linux, due to being case sensitive.

Resolves #5